### PR TITLE
feat: 新增 token 鉴权的 open-API(供后端编程化开号 / 授权 / 注销)

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,4 +256,68 @@ java -jar svnWebUI.jar --project.home=/home/svnWebUI/ --project.findPass=true
 
 --project.findPass 为是否打印用户名密码
 
+#### open-API(供后端自动化开号/授权)
+
+本 fork 新增了一组 HTTP open-API,供上游系统(如后端账号编排服务)以编程方式创建 svn 用户、覆盖式收敛其仓库授权、以及注销用户。API 不经过登录会话,依靠请求头令牌鉴权。
+
+##### 令牌注入(env)
+
+令牌通过环境变量 `SVNWEBUI_API_TOKEN` 注入:
+
+```
+docker run -e SVNWEBUI_API_TOKEN=<强随机令牌> ... cym1102/svnwebui
+```
+
+- **未配置(或为空)`SVNWEBUI_API_TOKEN` 时,整个 open-API 处于禁用状态**:任何 `/api/*` 请求一律返回 `success=false`,不读取请求体、不做任何数据库写入、不重写配置文件,svnWebUI 其余现有行为与未启用时完全一致(零副作用)。
+- 请求必须携带请求头 `X-Api-Token`,其值需与 `SVNWEBUI_API_TOKEN` 完全一致;缺失或不匹配时返回 `success=false, status=401`,且**在任何数据库写入之前**即被拒绝(鉴权失败不会产生任何副作用)。
+- 生产环境请务必仅经 HTTPS / 私网暴露本 API(令牌与口令以明文在请求体中传输)。
+
+##### 响应形状(JsonResult)
+
+所有接口 HTTP 状态码恒为 200,业务结果承载于 JSON 响应体(与站内其它接口一致):
+
+```json
+{ "success": true, "status": "200", "msg": null, "obj": null }
+```
+
+- `success`:布尔,业务是否成功(调用方应仅据此判定)。
+- `status`:字符串状态码(如鉴权失败为 `"401"`)。
+- `msg`:失败时的错误描述。
+
+##### POST /api/provision
+
+创建或更新用户,并以**覆盖式收敛**方式重写该用户在指定仓库下的授权(先清空该用户在该仓库的全部旧授权,再按 `paths` 全量写入)。仓库必须已存在(本接口不创建仓库)。
+
+请求头:`X-Api-Token: <令牌>`,`Content-Type: application/json`
+
+请求体:
+
+```json
+{
+  "user": "alice",
+  "pass": "明文口令",
+  "repo": "knowledge-repo",
+  "paths": [
+    { "path": "/knowledge", "permission": "r" },
+    { "path": "/knowledge/alice", "permission": "rw" }
+  ]
+}
+```
+
+- `permission` 取值 `r` / `rw`(与站内一致)。
+- 用户不存在则新建(普通用户 `type=0`、启用 `open=0`);已存在则更新其口令(改密幂等)。
+- 成功后重生成 `passwd` / `authz` 配置文件并返回 `success=true`。
+
+##### POST /api/revoke
+
+硬删用户及其全部授权(级联删除该用户在所有仓库下的 `RepositoryUser` 行),然后重生成配置文件。对不存在的用户调用也返回 `success=true`(幂等)。
+
+请求头:`X-Api-Token: <令牌>`
+
+请求体:
+
+```json
+{ "user": "alice", "repo": "knowledge-repo" }
+```
+
 运行成功后即可打印出全部用户名密码

--- a/README.md
+++ b/README.md
@@ -306,7 +306,10 @@ docker run -e SVNWEBUI_API_TOKEN=<强随机令牌> ... cym1102/svnwebui
 
 - `permission` 取值 `r` / `rw`(与站内一致)。
 - 用户不存在则新建(普通用户 `type=0`、启用 `open=0`);已存在则更新其口令(改密幂等)。
-- 成功后重生成 `passwd` / `authz` 配置文件并返回 `success=true`。
+- 成功后重生成 `passwd` / `authz` 配置文件。
+- **rw 目录预建**:成功后对每个 `rw` 授权路径,以本机 `file://`(与仓库同机、绕 authz、幂等)`svn mkdir --parents` 建好目录再返回 `success=true`。
+  原因:svnserve 下用户仅对父目录有 `r` 时无法在其下自建子目录(需父目录 `rw`,但那会破坏隔离);由本 API 预建后,用户仅需对自身目录有 `rw` 即可写文件。此步需服务器安装 **svn 客户端**;可用 `svnwebui.ensure-dir=false` 关闭、`svnwebui.svn-bin` 指定 svn 客户端路径(默认 `svn`)。
+- **输入校验**:`user`/`pass`/`path` 拒绝换行/控制符(防 passwd/authz 注入)、`path` 拒绝 `..`(防路径穿越)与 `[ ]`;非法输入在任何写入前即返回 `success=false`。
 
 ##### POST /api/revoke
 

--- a/src/main/java/com/cym/controller/ApiController.java
+++ b/src/main/java/com/cym/controller/ApiController.java
@@ -1,11 +1,17 @@
 package com.cym.controller;
 
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.noear.solon.Solon;
 import org.noear.solon.annotation.Controller;
 import org.noear.solon.annotation.Inject;
 import org.noear.solon.annotation.Mapping;
 import org.noear.solon.core.handle.Context;
 
+import com.cym.config.HomeConfig;
 import com.cym.model.Repository;
 import com.cym.model.RepositoryUser;
 import com.cym.model.User;
@@ -18,6 +24,7 @@ import com.cym.utils.BaseController;
 import com.cym.utils.JsonResult;
 import com.cym.utils.SvnAdminUtils;
 
+import cn.hutool.core.io.IoUtil;
 import cn.hutool.core.util.StrUtil;
 import cn.hutool.json.JSONArray;
 import cn.hutool.json.JSONObject;
@@ -45,6 +52,8 @@ public class ApiController extends BaseController {
 	SqlHelper sqlHelper;
 	@Inject
 	SvnAdminUtils svnAdminUtils;
+	@Inject
+	HomeConfig homeConfig;
 
 	/**
 	 * 读取 open-API token。生产以环境变量 SVNWEBUI_API_TOKEN 为准;env 空时回退配置项 svnwebui.api-token(测试注入用)。
@@ -121,7 +130,8 @@ public class ApiController extends BaseController {
 					.eq(RepositoryUser::getRepositoryId, repo.getId()), //
 					RepositoryUser.class);
 
-			// 6. 逐 path 重新写入期望授权
+			// 6. 逐 path 重新写入期望授权;同时收集 rw 目录待预建
+			List<String> rwDirs = new ArrayList<>();
 			JSONArray paths = body.getJSONArray("paths");
 			if (paths != null) {
 				for (int i = 0; i < paths.size(); i++) {
@@ -137,11 +147,18 @@ public class ApiController extends BaseController {
 					ru.setPath(path);
 					ru.setPermission(permission);
 					sqlHelper.insert(ru);
+					if ("rw".equalsIgnoreCase(permission)) {
+						rwDirs.add(path);
+					}
 				}
 			}
 
 			// 7. 重生成 passwd/authz 配置文件
 			configService.refresh();
+
+			// 8. 预建 rw 目录(co-located,file:// 绕 authz)。svnserve 要求对父目录有 rw 才能自建子目录,
+			//    仅授祖先 r 时用户无法自建自己的目录;open-API 与 repo 同机,直接建好目录,用户只需 rw 写文件。
+			ensureDirs(repo.getName(), rwDirs);
 
 			return renderSuccess();
 		} catch (Throwable t) {
@@ -176,6 +193,42 @@ public class ApiController extends BaseController {
 			return renderSuccess();
 		} catch (Throwable t) {
 			return renderError(t.getMessage());
+		}
+	}
+
+	/**
+	 * 预建 rw 目录(与 repo 同机,file:// 直接建、绕 authz、幂等)。
+	 *
+	 * <p>svnserve 语义下:用户仅对父目录有 r 时无法在其下自建子目录(E220004),必须对父目录有 rw——
+	 * 但给父目录 rw 会破坏隔离。故由 open-API 在本机预建用户目录,用户仅需自身目录 rw 即可写文件、
+	 * 且因父目录只有 r 无法建/删同级(隔离保持)。可用 {@code svnwebui.ensure-dir=false} 关闭、
+	 * {@code svnwebui.svn-bin} 指定 svn 客户端。
+	 */
+	private void ensureDirs(String repoName, List<String> rwPaths) throws Exception {
+		if (rwPaths == null || rwPaths.isEmpty()) {
+			return;
+		}
+		if ("false".equalsIgnoreCase(Solon.cfg().get("svnwebui.ensure-dir"))) {
+			return;
+		}
+		String svnBin = StrUtil.blankToDefault(Solon.cfg().get("svnwebui.svn-bin"), "svn");
+		for (String path : rwPaths) {
+			// File.toURI() 对非 ASCII(如中文仓库名)做 %-编码;getRawPath() 取编码后绝对路径
+			File dir = new File(homeConfig.home + "repo/" + repoName + path);
+			String url = "file://" + dir.toURI().getRawPath();
+			ProcessBuilder pb = new ProcessBuilder(svnBin, "mkdir", "--parents", "--non-interactive", "-q",
+					"-m", "auto-provision dir", url);
+			pb.redirectErrorStream(true);
+			Process proc = pb.start();
+			String out = IoUtil.read(proc.getInputStream(), StandardCharsets.UTF_8);
+			int code = proc.waitFor();
+			if (code != 0) {
+				// 目录已存在视为成功(幂等):svn E160020 / "already exists"
+				if (out != null && (out.contains("already exists") || out.contains("160020"))) {
+					continue;
+				}
+				throw new RuntimeException("ensureDir 失败: " + url + " :: " + (out == null ? "" : out.trim()));
+			}
 		}
 	}
 

--- a/src/main/java/com/cym/controller/ApiController.java
+++ b/src/main/java/com/cym/controller/ApiController.java
@@ -1,0 +1,182 @@
+package com.cym.controller;
+
+import org.noear.solon.Solon;
+import org.noear.solon.annotation.Controller;
+import org.noear.solon.annotation.Inject;
+import org.noear.solon.annotation.Mapping;
+import org.noear.solon.core.handle.Context;
+
+import com.cym.model.Repository;
+import com.cym.model.RepositoryUser;
+import com.cym.model.User;
+import com.cym.service.ConfigService;
+import com.cym.service.RepositoryService;
+import com.cym.service.UserService;
+import com.cym.sqlhelper.utils.ConditionAndWrapper;
+import com.cym.sqlhelper.utils.SqlHelper;
+import com.cym.utils.BaseController;
+import com.cym.utils.JsonResult;
+import com.cym.utils.SvnAdminUtils;
+
+import cn.hutool.core.util.StrUtil;
+import cn.hutool.json.JSONArray;
+import cn.hutool.json.JSONObject;
+import cn.hutool.json.JSONUtil;
+
+/**
+ * open-API:供后端(just-photo-admin)provision/revoke svn 账号与授权.
+ *
+ * <p>鉴权:请求头 {@code X-Api-Token} 必须与 token 一致;token 未配则整个 open-API 禁用(零副作用)。
+ * <p>token 来源以环境变量 {@code SVNWEBUI_API_TOKEN} 为准(生产路径);为便于自动化测试注入,
+ * 当 env 为空时回退读取配置项 {@code svnwebui.api-token}(生产不配置该项,故仍等价于 env-only)。
+ * <p>所有方法体全裹 try/catch(Throwable) 返 renderError,绝不外抛——AppFilter 的 catch(Throwable)
+ * 会吞掉未捕获异常导致空响应。
+ */
+@Controller
+@Mapping("/api")
+public class ApiController extends BaseController {
+	@Inject
+	UserService userService;
+	@Inject
+	RepositoryService repositoryService;
+	@Inject
+	ConfigService configService;
+	@Inject
+	SqlHelper sqlHelper;
+	@Inject
+	SvnAdminUtils svnAdminUtils;
+
+	/**
+	 * 读取 open-API token。生产以环境变量 SVNWEBUI_API_TOKEN 为准;env 空时回退配置项 svnwebui.api-token(测试注入用)。
+	 */
+	protected String getApiToken() {
+		String token = System.getenv("SVNWEBUI_API_TOKEN");
+		if (StrUtil.isEmpty(token)) {
+			token = Solon.cfg().get("svnwebui.api-token");
+		}
+		return token;
+	}
+
+	/**
+	 * token 校验(必须在任何 DB 写之前调用)。校验通过返 null,否则返对应错误响应。
+	 */
+	private JsonResult checkToken() {
+		String cfg = getApiToken();
+		if (StrUtil.isEmpty(cfg)) {
+			return renderError("api disabled");
+		}
+		String hdr = Context.current().header("X-Api-Token");
+		if (!cfg.equals(hdr)) {
+			return renderAuthError();
+		}
+		return null;
+	}
+
+	/**
+	 * provision:覆盖式收敛某 user 在某 repo 的授权。
+	 * 请求体 {user, pass, repo, paths:[{path, permission}]}。
+	 */
+	@Mapping("/provision")
+	public JsonResult provision() {
+		try {
+			// 1. token 校验(DB 写前)
+			JsonResult authError = checkToken();
+			if (authError != null) {
+				return authError;
+			}
+
+			JSONObject body = JSONUtil.parseObj(Context.current().body());
+
+			// 2. repo 必须存在(不建 repo)
+			Repository repo = repositoryService.getByName(body.getStr("repo"), null);
+			if (repo == null) {
+				return renderError("仓库不存在");
+			}
+
+			// 3. 排除保留(管理员)用户名
+			String uname = body.getStr("user");
+			if (StrUtil.isEmpty(uname)) {
+				return renderError("用户名为空");
+			}
+			if (svnAdminUtils.getAdminUserName().equals(uname)) {
+				return renderError("保留用户名");
+			}
+
+			// 4. 建号(open=0,普通用户)或改密幂等
+			User u = userService.getByName(uname, null);
+			if (u == null) {
+				u = new User();
+				u.setName(uname);
+				u.setPass(body.getStr("pass"));
+				u.setType(0);
+				sqlHelper.insert(u);
+			} else {
+				u.setPass(body.getStr("pass"));
+				sqlHelper.updateById(u);
+			}
+
+			// 5. 清空该 user 在该 repo 的全部旧授权(覆盖式收敛第一步)
+			sqlHelper.deleteByQuery(new ConditionAndWrapper()//
+					.eq(RepositoryUser::getUserId, u.getId())//
+					.eq(RepositoryUser::getRepositoryId, repo.getId()), //
+					RepositoryUser.class);
+
+			// 6. 逐 path 重新写入期望授权
+			JSONArray paths = body.getJSONArray("paths");
+			if (paths != null) {
+				for (int i = 0; i < paths.size(); i++) {
+					JSONObject p = paths.getJSONObject(i);
+					String path = p.getStr("path");
+					String permission = p.getStr("permission");
+					if (StrUtil.isEmpty(path) || StrUtil.isEmpty(permission)) {
+						continue;
+					}
+					RepositoryUser ru = new RepositoryUser();
+					ru.setRepositoryId(repo.getId());
+					ru.setUserId(u.getId());
+					ru.setPath(path);
+					ru.setPermission(permission);
+					sqlHelper.insert(ru);
+				}
+			}
+
+			// 7. 重生成 passwd/authz 配置文件
+			configService.refresh();
+
+			return renderSuccess();
+		} catch (Throwable t) {
+			return renderError(t.getMessage());
+		}
+	}
+
+	/**
+	 * revoke:硬删 user 及其全部授权(级联)。user 不存在也返 success(幂等)。
+	 * 请求体 {user, repo}。
+	 */
+	@Mapping("/revoke")
+	public JsonResult revoke() {
+		try {
+			// 1. token 校验(DB 写前)
+			JsonResult authError = checkToken();
+			if (authError != null) {
+				return authError;
+			}
+
+			JSONObject body = JSONUtil.parseObj(Context.current().body());
+
+			String uname = body.getStr("user");
+			User u = userService.getByName(uname, null);
+			if (u != null) {
+				// deleteById 级联删除该 user 全部 RepositoryUser/GroupUser
+				userService.deleteById(u.getId());
+			}
+
+			configService.refresh();
+
+			return renderSuccess();
+		} catch (Throwable t) {
+			return renderError(t.getMessage());
+		}
+	}
+
+}

--- a/src/main/java/com/cym/controller/ApiController.java
+++ b/src/main/java/com/cym/controller/ApiController.java
@@ -111,16 +111,24 @@ public class ApiController extends BaseController {
 				return renderError("保留用户名");
 			}
 
+			// 3.5 输入校验(在任何 DB 写之前):user/pass/path/permission 会进入 passwd/authz 文件
+			//     与 file:// 目录路径,拒绝换行/控制符(注入)、路径穿越(..)、authz 段字符,防越权。
+			String pass = body.getStr("pass");
+			String invalid = validate(uname, pass, body.getJSONArray("paths"));
+			if (invalid != null) {
+				return renderError(invalid);
+			}
+
 			// 4. 建号(open=0,普通用户)或改密幂等
 			User u = userService.getByName(uname, null);
 			if (u == null) {
 				u = new User();
 				u.setName(uname);
-				u.setPass(body.getStr("pass"));
+				u.setPass(pass);
 				u.setType(0);
 				sqlHelper.insert(u);
 			} else {
-				u.setPass(body.getStr("pass"));
+				u.setPass(pass);
 				sqlHelper.updateById(u);
 			}
 
@@ -194,6 +202,58 @@ public class ApiController extends BaseController {
 		} catch (Throwable t) {
 			return renderError(t.getMessage());
 		}
+	}
+
+	/**
+	 * 输入校验:user/pass/path/permission 会写入 passwd/authz 文件与 file:// 目录路径,
+	 * 需拒绝会破坏文件格式或越权的输入。合法返 null,非法返错误描述(调用方据此 renderError)。
+	 *
+	 * <ul>
+	 *   <li>user:非空、无换行/控制符、无 {@code / \ 空格 = : # [ ]}(passwd/authz 行与目录分隔符)。</li>
+	 *   <li>pass:无换行/控制符(否则可在 passwd 注入额外行)。</li>
+	 *   <li>path:以 / 开头、无换行/控制符、无 {@code ..}(file:// 路径穿越)、无 {@code [ ]}(authz 段头)。</li>
+	 *   <li>permission:仅 r / rw / no。</li>
+	 * </ul>
+	 */
+	private String validate(String user, String pass, JSONArray paths) {
+		if (hasCtrl(user) || StrUtil.containsAny(user, "/", "\\", " ", "=", ":", "#", "[", "]")) {
+			return "用户名含非法字符";
+		}
+		if (hasCtrl(pass)) {
+			return "口令含非法字符(换行/控制符)";
+		}
+		if (paths != null) {
+			for (int i = 0; i < paths.size(); i++) {
+				JSONObject p = paths.getJSONObject(i);
+				String path = p.getStr("path");
+				String permission = p.getStr("permission");
+				if (StrUtil.isEmpty(path) || StrUtil.isEmpty(permission)) {
+					continue;
+				}
+				if (!path.startsWith("/") || hasCtrl(path) || path.contains("..")
+						|| StrUtil.containsAny(path, "[", "]")) {
+					return "授权路径非法: " + path;
+				}
+				if (!"r".equals(permission) && !"rw".equals(permission) && !"no".equals(permission)) {
+					return "权限非法(仅 r/rw/no): " + permission;
+				}
+			}
+		}
+		return null;
+	}
+
+	/** 是否含换行 / 控制符(0x00-0x1F 或 0x7F);null 视为无。 */
+	private boolean hasCtrl(String s) {
+		if (s == null) {
+			return false;
+		}
+		for (int i = 0; i < s.length(); i++) {
+			char c = s.charAt(i);
+			if (c < 0x20 || c == 0x7f) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/src/main/java/com/cym/service/ConfigService.java
+++ b/src/main/java/com/cym/service/ConfigService.java
@@ -45,7 +45,24 @@ public class ConfigService {
 	@Inject
 	SvnAdminUtils svnAdminUtils;
 
+	// open-API 与 UI 触发的 refresh 共享同一进程内静态锁,串行化"读 SQLite→生成→原子替换"整段,防半截文件与 lost-update
+	private static final Object REFRESH_LOCK = new Object();
+
 	public void refresh() {
+		synchronized (REFRESH_LOCK) {
+			refreshInternal();
+		}
+	}
+
+	// 原子写:先写目标同目录的 .tmp,再 rename 覆盖目标(同分区即原子);tmp 必须落目标同目录,否则跨挂载退化为非原子复制
+	private void writeLinesAtomic(List<String> lines, String target) {
+		File targetFile = new File(target);
+		File tmpFile = new File(targetFile.getParentFile(), targetFile.getName() + ".tmp");
+		FileUtil.writeLines(lines, tmpFile, Charset.forName("UTF-8"));
+		FileUtil.move(tmpFile, targetFile, true);
+	}
+
+	private void refreshInternal() {
 		String passwd = null;
 		if (SystemTool.inDocker() && "http".equals(settingService.get("protocol"))) {
 			passwd = homeConfig.home + "repo/httpdPasswd";
@@ -76,7 +93,7 @@ public class ConfigService {
 				passwdLines.add(user.getName() + " = " + user.getPass());
 			}
 		}
-		FileUtil.writeLines(passwdLines, passwd, Charset.forName("UTF-8"));
+		writeLinesAtomic(passwdLines, passwd);
 
 		// 小组
 		List<String> authzLines = new ArrayList<>();
@@ -152,7 +169,7 @@ public class ConfigService {
 			FileUtil.writeFromStream(resource.getStream(), svnserve_conf);
 		}
 
-		FileUtil.writeLines(authzLines, authz, Charset.forName("UTF-8"));
+		writeLinesAtomic(authzLines, authz);
 
 		// 目录授权
 		if (SystemTool.inDocker() && "http".equals(settingService.get("protocol"))) {

--- a/src/test/java/com/cym/api/ApiControllerTest.java
+++ b/src/test/java/com/cym/api/ApiControllerTest.java
@@ -165,6 +165,37 @@ public class ApiControllerTest extends HttpTester {
 	}
 
 	// =========================================================================
+	// 输入校验:非法 user/pass/path/permission 在任何 DB 写之前被拒(防 passwd/authz 注入与路径穿越)
+	// =========================================================================
+	@Test
+	public void invalid_input_rejected_without_db_change() throws Exception {
+		enableToken();
+		createRepo();
+		long usersBefore = userCount();
+		long repoUsersBefore = repoUserCount();
+
+		// 路径穿越 ..
+		assertFalse(post("/api/provision", TOKEN,
+				"{\"user\":\"eve\",\"pass\":\"P\",\"repo\":\"" + REPO + "\",\"paths\":[{\"path\":\"/../evil\",\"permission\":\"rw\"}]}")
+				.getBool("success"), "路径含 .. 应被拒");
+		// 用户名含斜杠
+		assertFalse(post("/api/provision", TOKEN,
+				"{\"user\":\"a/b\",\"pass\":\"P\",\"repo\":\"" + REPO + "\",\"paths\":[{\"path\":\"/a\",\"permission\":\"rw\"}]}")
+				.getBool("success"), "用户名含 / 应被拒");
+		// 口令含换行(passwd 注入)
+		assertFalse(post("/api/provision", TOKEN,
+				"{\"user\":\"eve\",\"pass\":\"P\\ninject = x\",\"repo\":\"" + REPO + "\",\"paths\":[{\"path\":\"/a\",\"permission\":\"rw\"}]}")
+				.getBool("success"), "口令含换行应被拒");
+		// 非法权限
+		assertFalse(post("/api/provision", TOKEN,
+				"{\"user\":\"eve\",\"pass\":\"P\",\"repo\":\"" + REPO + "\",\"paths\":[{\"path\":\"/a\",\"permission\":\"rwx\"}]}")
+				.getBool("success"), "非法权限应被拒");
+
+		assertEquals(usersBefore, userCount(), "非法输入不得改动 User 行数");
+		assertEquals(repoUsersBefore, repoUserCount(), "非法输入不得改动 RepositoryUser 行数");
+	}
+
+	// =========================================================================
 	// SVNWEBUI-4: 覆盖式收敛 —— 预置 /a=rw,/b=rw → provision paths=[{/a,r}] → 仅剩 /a=r
 	// =========================================================================
 	@Test

--- a/src/test/java/com/cym/api/ApiControllerTest.java
+++ b/src/test/java/com/cym/api/ApiControllerTest.java
@@ -1,0 +1,249 @@
+package com.cym.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.noear.solon.Solon;
+import org.noear.solon.net.http.HttpUtils;
+import org.noear.solon.test.HttpTester;
+import org.noear.solon.test.SolonTest;
+
+import com.cym.SvnWebUI;
+import com.cym.model.GroupUser;
+import com.cym.model.Repository;
+import com.cym.model.RepositoryGroup;
+import com.cym.model.RepositoryUser;
+import com.cym.model.User;
+import com.cym.sqlhelper.utils.ConditionAndWrapper;
+import com.cym.sqlhelper.utils.SqlHelper;
+
+import cn.hutool.core.io.FileUtil;
+import cn.hutool.json.JSONObject;
+import cn.hutool.json.JSONUtil;
+
+/**
+ * open-API 验收测试(SVNWEBUI-1/2/3/4/7a)。
+ *
+ * <p>启动完整 Solon 容器(内嵌 undertow),经真实 HTTP 打 /api/*,覆盖 AppFilter + Controller + DB + refresh 全链路。
+ * <p>token 通过配置项 svnwebui.api-token 注入(生产仍以 env SVNWEBUI_API_TOKEN 为准);测试前后 put/remove 该配置项以切换启用/禁用。
+ * <p>DB 为内嵌 sqlite,home 指向 ./target/svnWebUI-test/(静态块预建,避免 HomeConfig 不可写→System.exit)。
+ */
+@SolonTest(value = SvnWebUI.class, properties = { "project.home=./target/svnWebUI-test/", "database.type=sqlite", "server.port=16060" })
+public class ApiControllerTest extends HttpTester {
+
+	static final String TEST_HOME = "./target/svnWebUI-test/";
+	static final String TOKEN_KEY = "svnwebui.api-token";
+	static final String TOKEN = "secret-token-123";
+	static final String REPO = "knowledge-repo";
+
+	static {
+		// HomeConfig.init 会对 home 目录做 canWrite 检查,不可写则 System.exit(1);启动前先建好目录
+		FileUtil.mkdir(new File(TEST_HOME));
+	}
+
+	SqlHelper sqlHelper() {
+		return Solon.context().getBean(SqlHelper.class);
+	}
+
+	void enableToken() {
+		Solon.cfg().put(TOKEN_KEY, TOKEN);
+	}
+
+	void disableToken() {
+		Solon.cfg().remove(TOKEN_KEY);
+	}
+
+	@BeforeEach
+	public void clean() {
+		SqlHelper sqlHelper = sqlHelper();
+		sqlHelper.deleteByQuery(new ConditionAndWrapper(), User.class);
+		sqlHelper.deleteByQuery(new ConditionAndWrapper(), RepositoryUser.class);
+		sqlHelper.deleteByQuery(new ConditionAndWrapper(), RepositoryGroup.class);
+		sqlHelper.deleteByQuery(new ConditionAndWrapper(), GroupUser.class);
+		sqlHelper.deleteByQuery(new ConditionAndWrapper(), Repository.class);
+		disableToken();
+	}
+
+	// ---- HTTP 辅助 ----
+
+	JSONObject post(String apiPath, String token, String jsonBody) throws Exception {
+		HttpUtils req = path(apiPath);
+		if (token != null) {
+			req.header("X-Api-Token", token);
+		}
+		String resp = req.bodyOfJson(jsonBody).post();
+		return JSONUtil.parseObj(resp);
+	}
+
+	String repoId() {
+		Repository repo = sqlHelper().findOneByQuery(new ConditionAndWrapper().eq(Repository::getName, REPO), Repository.class);
+		return repo == null ? null : repo.getId();
+	}
+
+	void createRepo() {
+		Repository repo = new Repository();
+		repo.setName(REPO);
+		sqlHelper().insert(repo); // @InitValue: enable=true, allPermission=no
+	}
+
+	long userCount() {
+		return sqlHelper().findCountByQuery(new ConditionAndWrapper(), User.class);
+	}
+
+	long repoUserCount() {
+		return sqlHelper().findCountByQuery(new ConditionAndWrapper(), RepositoryUser.class);
+	}
+
+	User getUser(String name) {
+		return sqlHelper().findOneByQuery(new ConditionAndWrapper().eq(User::getName, name), User.class);
+	}
+
+	List<RepositoryUser> repoUsersOf(String userId) {
+		return sqlHelper().findListByQuery(new ConditionAndWrapper().eq(RepositoryUser::getUserId, userId), RepositoryUser.class);
+	}
+
+	// =========================================================================
+	// SVNWEBUI-1: token 未配则整个 open-API 禁用,不执行任何 DB 写
+	// =========================================================================
+	@Test
+	public void token_not_configured_disables_api() throws Exception {
+		disableToken();
+		createRepo();
+		long usersBefore = userCount();
+
+		String body = "{\"user\":\"alice\",\"pass\":\"P\",\"repo\":\"" + REPO + "\",\"paths\":[{\"path\":\"/a\",\"permission\":\"r\"}]}";
+		JSONObject resp = post("/api/provision", TOKEN, body);
+
+		assertFalse(resp.getBool("success"), "token 未配时应 success=false");
+		assertEquals(usersBefore, userCount(), "禁用状态下不得新增 user");
+		assertNull(getUser("alice"), "禁用状态下不得创建 alice");
+	}
+
+	// =========================================================================
+	// SVNWEBUI-3: 鉴权失败(错误 token)→ success=false, status=401, 且无任何 DB 变化
+	// =========================================================================
+	@Test
+	public void wrong_token_returns_401_and_no_db_change() throws Exception {
+		enableToken();
+		createRepo();
+		// 预置一个已有用户与授权,作为"无副作用"的基线
+		User existing = new User();
+		existing.setName("bob");
+		existing.setPass("oldpass");
+		existing.setType(0);
+		sqlHelper().insert(existing);
+		RepositoryUser ru = new RepositoryUser();
+		ru.setUserId(existing.getId());
+		ru.setRepositoryId(repoId());
+		ru.setPath("/x");
+		ru.setPermission("rw");
+		sqlHelper().insert(ru);
+
+		long usersBefore = userCount();
+		long repoUsersBefore = repoUserCount();
+
+		String body = "{\"user\":\"alice\",\"pass\":\"P\",\"repo\":\"" + REPO + "\",\"paths\":[{\"path\":\"/a\",\"permission\":\"r\"}]}";
+		JSONObject resp = post("/api/provision", "WRONG-TOKEN", body);
+
+		assertFalse(resp.getBool("success"), "错误 token 应 success=false");
+		assertEquals("401", resp.getStr("status"), "错误 token 应 status=401");
+		assertEquals(usersBefore, userCount(), "鉴权失败不得改动 User 行数");
+		assertEquals(repoUsersBefore, repoUserCount(), "鉴权失败不得改动 RepositoryUser 行数");
+		// bob 授权保持不变
+		assertEquals("rw", getUser("bob") == null ? null : repoUsersOf(getUser("bob").getId()).get(0).getPermission());
+	}
+
+	// =========================================================================
+	// SVNWEBUI-4: 覆盖式收敛 —— 预置 /a=rw,/b=rw → provision paths=[{/a,r}] → 仅剩 /a=r
+	// =========================================================================
+	@Test
+	public void provision_converges_authz_overwrite() throws Exception {
+		enableToken();
+		createRepo();
+		// provision alice 初始 /a=rw,/b=rw
+		String body1 = "{\"user\":\"alice\",\"pass\":\"P\",\"repo\":\"" + REPO
+				+ "\",\"paths\":[{\"path\":\"/a\",\"permission\":\"rw\"},{\"path\":\"/b\",\"permission\":\"rw\"}]}";
+		JSONObject resp1 = post("/api/provision", TOKEN, body1);
+		assertTrue(resp1.getBool("success"), "首次 provision 应成功");
+
+		User alice = getUser("alice");
+		assertNotNull(alice, "alice 应被创建");
+		assertEquals(2, repoUsersOf(alice.getId()).size(), "初始应有 2 条授权");
+
+		// 覆盖式收敛:仅保留 /a=r
+		String body2 = "{\"user\":\"alice\",\"pass\":\"P\",\"repo\":\"" + REPO + "\",\"paths\":[{\"path\":\"/a\",\"permission\":\"r\"}]}";
+		JSONObject resp2 = post("/api/provision", TOKEN, body2);
+		assertTrue(resp2.getBool("success"), "收敛 provision 应成功");
+
+		List<RepositoryUser> rus = repoUsersOf(alice.getId());
+		assertEquals(1, rus.size(), "收敛后应仅剩 1 条授权(/b 被删)");
+		assertEquals("/a", rus.get(0).getPath(), "唯一授权应为 /a");
+		assertEquals("r", rus.get(0).getPermission(), "/a 应从 rw 降为 r");
+	}
+
+	// =========================================================================
+	// SVNWEBUI-2/4: 新建 user → open=0、type=0,authz 文件含其行;已存在 user → 改密幂等
+	// =========================================================================
+	@Test
+	public void new_user_open_zero_and_existing_user_password_idempotent() throws Exception {
+		enableToken();
+		createRepo();
+
+		String body1 = "{\"user\":\"carol\",\"pass\":\"pass1\",\"repo\":\"" + REPO + "\",\"paths\":[{\"path\":\"/knowledge/carol\",\"permission\":\"rw\"}]}";
+		JSONObject resp1 = post("/api/provision", TOKEN, body1);
+		assertTrue(resp1.getBool("success"), "新建 provision 应成功");
+
+		User carol = getUser("carol");
+		assertNotNull(carol, "carol 应被创建");
+		assertEquals(Integer.valueOf(0), carol.getOpen(), "新建 user 的 open 应为 0(启用)");
+		assertEquals(Integer.valueOf(0), carol.getType(), "新建 user 的 type 应为 0(普通用户)");
+		assertEquals("pass1", carol.getPass());
+
+		// authz 文件应重生成且包含 carol 的授权行
+		File authz = new File(TEST_HOME + "repo/authz");
+		assertTrue(authz.exists(), "authz 文件应被重生成");
+		String authzContent = FileUtil.readString(authz, Charset.forName("UTF-8"));
+		assertTrue(authzContent.contains("carol = rw"), "authz 应含 carol 的授权行,实际:\n" + authzContent);
+
+		// 已存在 user provision → 改密幂等,不新增 user
+		long usersBefore = userCount();
+		String body2 = "{\"user\":\"carol\",\"pass\":\"pass2\",\"repo\":\"" + REPO + "\",\"paths\":[{\"path\":\"/knowledge/carol\",\"permission\":\"rw\"}]}";
+		JSONObject resp2 = post("/api/provision", TOKEN, body2);
+		assertTrue(resp2.getBool("success"), "改密 provision 应成功");
+		assertEquals(usersBefore, userCount(), "已存在 user 不得新增行");
+		assertEquals("pass2", getUser("carol").getPass(), "pass 应被更新为 pass2");
+	}
+
+	// =========================================================================
+	// SVNWEBUI-7a: revoke 硬删 user 及授权;再次 revoke 同 user 仍 success(幂等)
+	// =========================================================================
+	@Test
+	public void revoke_hard_deletes_and_is_idempotent() throws Exception {
+		enableToken();
+		createRepo();
+		post("/api/provision", TOKEN,
+				"{\"user\":\"dave\",\"pass\":\"P\",\"repo\":\"" + REPO + "\",\"paths\":[{\"path\":\"/a\",\"permission\":\"rw\"}]}");
+		User dave = getUser("dave");
+		assertNotNull(dave, "dave 应存在");
+		assertTrue(repoUsersOf(dave.getId()).size() > 0, "dave 应有授权");
+
+		String revokeBody = "{\"user\":\"dave\",\"repo\":\"" + REPO + "\"}";
+		JSONObject resp1 = post("/api/revoke", TOKEN, revokeBody);
+		assertTrue(resp1.getBool("success"), "revoke 应成功");
+		assertNull(getUser("dave"), "dave 用户应被删除");
+		assertEquals(0, repoUsersOf(dave.getId()).size(), "dave 全部授权应被删除");
+
+		// 幂等:再次 revoke 同 user 仍 success
+		JSONObject resp2 = post("/api/revoke", TOKEN, revokeBody);
+		assertTrue(resp2.getBool("success"), "对不存在的 user revoke 仍应 success(幂等)");
+	}
+}

--- a/src/test/java/com/cym/api/ApiControllerTest.java
+++ b/src/test/java/com/cym/api/ApiControllerTest.java
@@ -71,6 +71,8 @@ public class ApiControllerTest extends HttpTester {
 		sqlHelper.deleteByQuery(new ConditionAndWrapper(), GroupUser.class);
 		sqlHelper.deleteByQuery(new ConditionAndWrapper(), Repository.class);
 		disableToken();
+		// 单测无真实 svn repo,关闭 rw 目录预建(file:// mkdir);建目录能力由灰度/E2E 验证
+		Solon.cfg().put("svnwebui.ensure-dir", "false");
 	}
 
 	// ---- HTTP 辅助 ----


### PR DESCRIPTION
## 背景 / 动机

svnWebUI 的管理能力目前只暴露在**登录会话 + 图形验证码**的 Web 界面上。当上游系统(如公司内的账号编排后端)需要**自动化**地为用户开通 SVN 账号、下发目录授权、离职时注销时,没有可编程接口可用——只能人工点界面,或绕开 svnWebUI 直接改 `passwd`/`authz`(但那样会被 svnWebUI 的 `ConfigService.refresh()` 全量重生成时覆盖)。

本 PR 新增一组**令牌鉴权的 HTTP open-API**,让外部系统以 svnWebUI 的 SQLite 为唯一权威、通过接口安全地管理用户与授权,天然与界面操作一致(都经由 `refresh()` 重生成配置)。

## 改动概览

- 新增 `ApiController`(`/api/provision`、`/api/revoke`),独立于 `adminPage` 会话鉴权,使用请求头令牌。
- `ConfigService.refresh()` 增加**进程内串行锁 + 临时文件原子替换**,修复并发刷新可能撕裂 `passwd`/`authz` 的问题(界面并发操作同样受益)。
- README 增补 open-API 文档。
- 新增单元测试(`solon-test`,6 项)。

改动面:4 文件,+663/-2。**未配置令牌时对现有行为零影响**(见下)。

## 接口

所有接口 HTTP 状态码恒为 200,业务结果承载于 JSON 响应体 `{success, status, msg, obj}`(与站内一致),调用方仅据 `success` 判定。

- **`POST /api/provision`** `{user, pass, repo, paths:[{path, permission}]}`:创建或更新用户,并以**覆盖式收敛**重写该用户在指定仓库下的授权(先清空其在该仓库的旧授权,再按 `paths` 全量写入)。仓库须已存在(不创建仓库)。
- **`POST /api/revoke`** `{user, repo}`:硬删用户及其全部授权(幂等,对不存在用户也返 success)。

## 向后兼容(重要)

- 令牌通过环境变量 `SVNWEBUI_API_TOKEN` 注入。**未配置(或为空)时整个 open-API 处于禁用状态**:任何 `/api/*` 一律返回 `success=false`,不读请求体、不做任何写入,svnWebUI 其余行为与打补丁前**完全一致**。
- 请求须携带 `X-Api-Token`,值不匹配 → `success=false, status=401`,且**在任何数据库写入之前**即被拒绝(鉴权失败零副作用)。
- 由于 `/api/*` 不含 `adminPage`,不经过现有 `AppFilter` 的会话校验;controller 内部全程捕获异常并以 `JsonResult` 返回,避免 `AppFilter` 吞异常导致空响应。

## 关键实现点

1. **`refresh()` 并发安全**:原实现直接 `FileUtil.writeLines` 覆盖 `passwd`/`authz`,无锁、非原子。改为静态锁包裹 + 写同目录临时文件后 `FileUtil.move` 原子替换,兼顾"防半截文件"与"防陈旧快照覆盖"。
2. **`rw` 目录预建(可开关)**:`provision` 成功后,对每个 `rw` 授权路径以本机 `file://`(与仓库同机、绕 authz、幂等)`svn mkdir --parents` 预建目录。
   - 原因:**svnserve** 下用户仅对父目录有 `r` 时无法在其下自建子目录(需父目录 `rw`,但那会破坏隔离);由本 API 预建后,用户仅需对自身目录有 `rw` 即可写文件,父目录只读 → 无法建/删同级(隔离保持)。`mod_dav_svn`(http)无此限制,该步幂等无害。
   - 需服务器安装 `svn` 客户端;可用 `svnwebui.ensure-dir=false` 关闭、`svnwebui.svn-bin` 指定客户端路径(默认 `svn`)。
3. **输入校验**:`user`/`pass`/`path` 会进入 `passwd`/`authz` 文件与 `file://` 路径,故在任何写入前校验——拒绝换行/控制符(防注入额外配置行)、`path` 拒绝 `..`(防路径穿越)与 `[ ]`(防 authz 段头),`permission` 仅 `r/rw/no`。

## 配置项

| 键 | 说明 | 默认 |
|---|---|---|
| `SVNWEBUI_API_TOKEN`(env) | open-API 令牌;为空则整个 API 禁用 | 空(禁用) |
| `svnwebui.ensure-dir` | 是否预建 rw 目录 | `true` |
| `svnwebui.svn-bin` | 预建目录用的 svn 客户端 | `svn` |

## 测试

新增 `ApiControllerTest`(6 项,`solon-test` 全容器启动 + 内嵌 SQLite + 真实 HTTP):令牌未配禁用、错误令牌 401 且无 DB 变化、覆盖式收敛(增删/降权)、新建用户 `open=0` 且改密幂等、硬删幂等、非法输入被拒且无副作用。`mvn clean test` 全绿。

## 安全须知

令牌是管理级凭据(可建号/改授权/删号)。请**仅经 HTTPS 或私网**暴露本 API(令牌与口令以明文在请求体中传输),并妥善保管、定期轮换。

## 可讨论点(供 maintainer)

- 令牌比较目前用 `equals`(令牌为高熵随机串,timing 攻击不实际);如需可改常量时间比较。
- `ensure-dir` 默认开启;如更偏好保守,可改为默认关闭 + 文档引导按需开启。
- open-API 的注释/文档为中文,与项目一致;如需英文可补。